### PR TITLE
Add support for not following redirects

### DIFF
--- a/lib/adapters/http.js
+++ b/lib/adapters/http.js
@@ -3,8 +3,10 @@
 var utils = require('./../utils');
 var buildURL = require('./../helpers/buildURL');
 var transformData = require('./../helpers/transformData');
-var http = require('follow-redirects').http;
-var https = require('follow-redirects').https;
+var http = require('http');
+var https = require('https');
+var httpFollow = require('follow-redirects').http;
+var httpsFollow = require('follow-redirects').https;
 var url = require('url');
 var zlib = require('zlib');
 var pkg = require('./../../package.json');
@@ -71,7 +73,15 @@ module.exports = function httpAdapter(resolve, reject, config) {
   }
 
   // Create the request
-  var transport = parsed.protocol === 'https:' ? https : http;
+  var transport;
+  if (config.maxRedirects === 0) {
+    transport = parsed.protocol === 'https:' ? https : http;
+  } else {
+    if (config.maxRedirects) {
+      options.maxRedirects = config.maxRedirects;
+    }
+    transport = parsed.protocol === 'https:' ? httpsFollow : httpFollow;
+  }
   var req = transport.request(options, function handleResponse(res) {
     if (aborted) return;
 

--- a/test/unit/adapters/http.js
+++ b/test/unit/adapters/http.js
@@ -175,5 +175,34 @@ module.exports = {
         });
       });
     });
+  },
+
+  testNoRedirect: function(test) {
+    var str = 'test response';
+
+    server = http.createServer(function (req, res) {
+      var parsed = url.parse(req.url);
+
+      if (parsed.pathname === '/one') {
+        res.setHeader('NoRedirect', true);
+        res.setHeader('Location', '/two');
+        res.statusCode = 302;
+        res.end();
+      } else {
+        res.end(str);
+      }
+    }).listen(4444, function() {
+      axios.get('http://localhost:4444/one', {
+        maxRedirects: 0,
+        validateStatus: function(status) {
+          return status >= 200 && status < 400;
+        }
+      }).then(function(res) {
+        test.equal(res.status, 302);
+        test.equal(res.headers['noredirect'], 'true');
+        test.equal(res.headers['location'], '/two');
+        test.done();
+      });
+    });
   }
 };


### PR DESCRIPTION
Axios, by default, always follow redirects. This PR adds support for not following redirects. It was shamelessly ripped from an existing PR sitting on the main axios repo. It is intended that once this functionality is merged into Axios master this fork will be deleted and we'll swap back over to the originaly repo.

@ventureco/code-reviewers 
